### PR TITLE
add user feedback for e7 run and Bing initial provisioning error

### DIFF
--- a/e5-connectors/notebook.ipynb
+++ b/e5-connectors/notebook.ipynb
@@ -122,7 +122,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> ✅ Keep in mind that getting a Bing Web Search API key will require you to have a fresh FREE Azure account, or else a paid Azure account with active billing credentials."
+    "> ✅ Keep in mind that getting a Bing Web Search API key will require you to have a fresh FREE Azure account, or else a paid Azure account with active billing credentials.\n",
+    "\n",
+    "> 🤔 **Get `\"Error: Response status code does not indicate success: 401 (PermissionDenied).\"` message?** This could happen if you just provisioned a Bing Web Search API. Wait a few minutes and try again. \n",
+    "\n",
+    "> 😱 **Get a different error message?** go to https://aka.ms/sk/discord where we have realtime support available to troubleshoot your problem."
    ]
   },
   {

--- a/e7-bonus-chat/notebook.ipynb
+++ b/e7-bonus-chat/notebook.ipynb
@@ -157,7 +157,7 @@
     "    try {\n",
     "        // get input from the user and set the context variable\n",
     "        Console.WriteLine(\"👆 Enter text in the input cell above to chat with the bot. 👆\\n\");\n",
-    "        var input = await InteractiveKernel.GetInputAsync(botPrompt);\n",
+    "        var input = await InteractiveKernel.GetInputAsync($\"{botPrompt} ({(i+1)} of {numberOfRounds})\");\n",
     "        myContext.Set(\"input\", input); \n",
     "\n",
     "        // run the chat function\n",


### PR DESCRIPTION
- Add additional context to user input in Simple Chat loop (`Step 2.1` in `e7-bonus-chat`)
![image](https://user-images.githubusercontent.com/18152044/230445788-1caa7527-8b62-48a9-b6ce-77a3e8110c6d.png)

- When a user initially provisions Bing Search API (likely to happen on initial run), there could be an inadvertent error(s), one of which happened to me with a 401 error:
![image](https://user-images.githubusercontent.com/18152044/230446486-9c6a3496-e33c-4f12-bc3c-73fe91e50b01.png)

However, the issue was resolved after waiting:
![image](https://user-images.githubusercontent.com/18152044/230446552-c70d34ee-b336-4352-9617-3001dba0207a.png)

So, similar to E2-Step3.3, I added some additional information for the user in case they encounter a similar problem
![image](https://user-images.githubusercontent.com/18152044/230446937-f74cb8eb-effd-45bb-b5c9-d24da5b7e85c.png)

