### PR TITLE
Fix typo - change Europe to New York City

### DIFF
--- a/e5-connectors/notebook.ipynb
+++ b/e5-connectors/notebook.ipynb
@@ -82,7 +82,7 @@
    "source": [
     "## Step 2: Integrate live data with the Bing Web Search API 🍋 connector\n",
     "\n",
-    "To get a Bing Web Search API key visit [this resource](https://www.microsoft.com/en-us/bing/apis/bing-web-search-api) to start. Once you have that in hand, you can now grab live search information to get added to the context of your choice. For example, we can find out what's the tallest building in Europe:"
+    "To get a Bing Web Search API key visit [this resource](https://www.microsoft.com/en-us/bing/apis/bing-web-search-api) to start. Once you have that in hand, you can now grab live search information to get added to the context of your choice. For example, we can find out what's the tallest building in New York City:"
    ]
   },
   {


### PR DESCRIPTION
Changing explanation of code to include the correct location.