### PR TITLE
Convert PasswordString to String

### DIFF
--- a/config/Settings.cs
+++ b/config/Settings.cs
@@ -92,12 +92,12 @@ public static class Settings
         {
             if (useAzureOpenAI)
             {
-                apiKey = (await InteractiveKernel.GetPasswordAsync("Please enter your Azure OpenAI API key")).ToString();
+                apiKey = (await InteractiveKernel.GetPasswordAsync("Please enter your Azure OpenAI API key")).GetClearTextPassword();
                 orgId = "";
             }
             else
             {
-                apiKey = (await InteractiveKernel.GetPasswordAsync("Please enter your OpenAI API key")).ToString();
+                apiKey = (await InteractiveKernel.GetPasswordAsync("Please enter your OpenAI API key")).GetClearTextPassword();
             }
         }
 

--- a/config/Settings.cs
+++ b/config/Settings.cs
@@ -92,12 +92,12 @@ public static class Settings
         {
             if (useAzureOpenAI)
             {
-                apiKey = await InteractiveKernel.GetPasswordAsync("Please enter your Azure OpenAI API key");
+                apiKey = (await InteractiveKernel.GetPasswordAsync("Please enter your Azure OpenAI API key")).ToString();
                 orgId = "";
             }
             else
             {
-                apiKey = await InteractiveKernel.GetPasswordAsync("Please enter your OpenAI API key");
+                apiKey = (await InteractiveKernel.GetPasswordAsync("Please enter your OpenAI API key")).ToString();
             }
         }
 


### PR DESCRIPTION
This PR is for fixing the issue mentioned here: https://github.com/johnmaeda/SK-Recipes/issues/8

The root cause I believe is that the `Settings.cs` cannot be compiled because of this error:

```
Cannot implicitly convert type 'Microsoft.DotNet.Interactive.PasswordString' to 'string'
```

And since `PasswordString` has a [ToString()](https://github.com/dotnet/interactive/blob/ae21674db37a10d9e0f2376d41a705933f0d947e/src/Microsoft.DotNet.Interactive/PasswordString.cs#L21) method, we can simply invoke it and so that the compiler is happy and hence the notebote will be happy.

