### PR TITLE
fix a issue, when you run the first code block in e2-first-dish.ipynb…

### DIFF
--- a/config/Settings.cs
+++ b/config/Settings.cs
@@ -92,12 +92,12 @@ public static class Settings
         {
             if (useAzureOpenAI)
             {
-                apiKey = await InteractiveKernel.GetPasswordAsync("Please enter your Azure OpenAI API key");
+                apiKey = (await InteractiveKernel.GetPasswordAsync("Please enter your Azure OpenAI API key")).GetClearTextPassword();
                 orgId = "";
             }
             else
             {
-                apiKey = await InteractiveKernel.GetPasswordAsync("Please enter your OpenAI API key");
+                apiKey =(await InteractiveKernel.GetPasswordAsync("Please enter your OpenAI API key")).GetClearTextPassword();
             }
         }
 


### PR DESCRIPTION
fix a issue, when you run the first code blocker in e2-first-dish.ipynb , there is a error message:

Error: (95,26): error CS0029: Cannot implicitly convert type 'Microsoft.DotNet.Interactive.PasswordString' to 'string'

(100,25): error CS0029: Cannot implicitly convert type 'Microsoft.DotNet.Interactive.PasswordString' to 'string'